### PR TITLE
Added function to retrieve full block information via RPC

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -137,6 +137,66 @@ namespace currency
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_block(const COMMAND_RPC_GET_BLOCK::request& req, COMMAND_RPC_GET_BLOCK::response& res, epee::json_rpc::error& error_resp, connection_context& cntx){
+	  if(!check_core_ready())
+	  {
+		error_resp.code = CORE_RPC_ERROR_CODE_CORE_BUSY;
+		error_resp.message = "Core is busy.";
+		return false;
+	  }
+      crypto::hash block_hash;
+      if (!req.hash.empty())
+      {
+        bool hash_parsed = parse_hash256(req.hash, block_hash);
+        if(!hash_parsed)
+        {
+          error_resp.code = CORE_RPC_ERROR_CODE_WRONG_PARAM;
+          error_resp.message = "Failed to parse hex representation of block hash. Hex = " + req.hash + '.';
+          return false;
+        }
+      }
+      else
+      {
+        if(m_core.get_current_blockchain_height() <= req.height)
+        {
+          error_resp.code = CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT;
+          error_resp.message = std::string("Too big height: ") + std::to_string(req.height) + ", current blockchain height = " +  std::to_string(m_core.get_current_blockchain_height());
+          return false;
+        }
+        block_hash = m_core.get_block_id_by_height(req.height);
+      }
+      block blk;
+      bool have_block = m_core.get_block_by_hash(block_hash, blk);
+      if (!have_block)
+      {
+        error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+        error_resp.message = "Internal error: can't get block by hash. Hash = " + req.hash + '.';
+        return false;
+      }
+      if (blk.miner_tx.vin.front().type() != typeid(txin_gen))
+      {
+        error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+        error_resp.message = "Internal error: coinbase transaction in the block has the wrong type";
+        return false;
+      }
+      uint64_t block_height = boost::get<txin_gen>(blk.miner_tx.vin.front()).height;
+      bool response_filled = fill_block_header_response(blk, false, res.block_header);
+      if (!response_filled)
+      {
+        error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+        error_resp.message = "Internal error: can't produce valid response.";
+        return false;
+      }
+      for (size_t n = 0; n < blk.tx_hashes.size(); ++n)
+      {
+        res.tx_hashes.push_back(epee::string_tools::pod_to_hex(blk.tx_hashes[n]));
+      }
+      res.blob = string_tools::buff_to_hex_nodelimer(t_serializable_object_to_blob(blk));
+      res.json = obj_to_json_str(blk);
+      res.status = CORE_RPC_STATUS_OK;
+      return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_random_outs(const COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::request& req, COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::response& res, connection_context& cntx)
   {
     CHECK_CORE_READY();
@@ -528,7 +588,7 @@ namespace currency
     return reward;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  bool core_rpc_server::fill_block_header_responce(const block& blk, bool orphan_status, block_header_responce& responce)
+  bool core_rpc_server::fill_block_header_response(const block& blk, bool orphan_status, block_header_response& responce)
   {
     responce.major_version = blk.major_version;
     responce.minor_version = blk.minor_version;
@@ -560,7 +620,7 @@ namespace currency
       error_resp.message = "Internal error: can't get last block hash.";
       return false;
     }
-    bool responce_filled = fill_block_header_responce(last_block, false, res.block_header);
+    bool responce_filled = fill_block_header_response(last_block, false, res.block_header);
     if (!responce_filled)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
@@ -601,7 +661,7 @@ namespace currency
       return false;
     }
     uint64_t block_height = boost::get<txin_gen>(blk.miner_tx.vin.front()).height;
-    bool responce_filled = fill_block_header_responce(blk, false, res.block_header);
+    bool responce_filled = fill_block_header_response(blk, false, res.block_header);
     if (!responce_filled)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
@@ -628,7 +688,7 @@ namespace currency
     block blk = AUTO_VAL_INIT(blk);
     bool r = m_core.get_blockchain_storage().get_block_by_height(req.height, blk);
     
-    bool responce_filled = fill_block_header_responce(blk, false, res.block_header);
+    bool responce_filled = fill_block_header_response(blk, false, res.block_header);
     if (!responce_filled)
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
@@ -647,6 +707,7 @@ namespace currency
       error_resp.message = "Core is busy.";
       return false;
     }
+
     alias_info_base aib = AUTO_VAL_INIT(aib);
     if(!validate_alias_name(req.alias))
     {      
@@ -862,6 +923,13 @@ namespace currency
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_alias_by_address(const COMMAND_RPC_GET_ALIASES_BY_ADDRESS::request& req, COMMAND_RPC_GET_ALIASES_BY_ADDRESS::response& res, epee::json_rpc::error& error_resp, connection_context& cntx)
   {
+	if(!check_core_ready())
+	{
+		error_resp.code = CORE_RPC_ERROR_CODE_CORE_BUSY;
+		error_resp.message = "Core is busy.";
+		return false;
+	}
+
     account_public_address addr = AUTO_VAL_INIT(addr);
     if (!get_account_address_from_str(addr, req))
     {

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -51,6 +51,7 @@ namespace currency
     bool on_get_last_block_header(const COMMAND_RPC_GET_LAST_BLOCK_HEADER::request& req, COMMAND_RPC_GET_LAST_BLOCK_HEADER::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
     bool on_get_block_header_by_hash(const COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH::request& req, COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
     bool on_get_block_header_by_height(const COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
+    bool on_get_block(const COMMAND_RPC_GET_BLOCK::request& req, COMMAND_RPC_GET_BLOCK::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
     bool on_get_alias_details(const COMMAND_RPC_GET_ALIAS_DETAILS::request& req, COMMAND_RPC_GET_ALIAS_DETAILS::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
     bool on_get_all_aliases(const COMMAND_RPC_GET_ALL_ALIASES::request& req, COMMAND_RPC_GET_ALL_ALIASES::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
     bool on_alias_by_address(const COMMAND_RPC_GET_ALIASES_BY_ADDRESS::request& req, COMMAND_RPC_GET_ALIASES_BY_ADDRESS::response& res, epee::json_rpc::error& error_resp, connection_context& cntx);
@@ -94,6 +95,7 @@ namespace currency
         MAP_JON_RPC_WE("getlastblockheader",     on_get_last_block_header,      COMMAND_RPC_GET_LAST_BLOCK_HEADER)
         MAP_JON_RPC_WE("getblockheaderbyhash",   on_get_block_header_by_hash,   COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH)
         MAP_JON_RPC_WE("getblockheaderbyheight", on_get_block_header_by_height, COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT)
+        MAP_JON_RPC_WE("getblock", 				 on_get_block, 					COMMAND_RPC_GET_BLOCK)
         MAP_JON_RPC_WE("get_alias_details",      on_get_alias_details,          COMMAND_RPC_GET_ALIAS_DETAILS)
         MAP_JON_RPC_WE("get_all_alias_details",  on_get_all_aliases,            COMMAND_RPC_GET_ALL_ALIASES)
         MAP_JON_RPC_WE("get_alias_by_address",   on_alias_by_address,           COMMAND_RPC_GET_ALIASES_BY_ADDRESS)
@@ -119,7 +121,7 @@ namespace currency
 
     //utils
     uint64_t get_block_reward(const block& blk);
-    bool fill_block_header_responce(const block& blk, bool orphan_status, block_header_responce& responce);
+    bool fill_block_header_response(const block& blk, bool orphan_status, block_header_response& responce);
     void set_session_blob(const std::string& session_id, const currency::block& blob);
     bool get_session_blob(const std::string& session_id, currency::block& blob);
     

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -451,7 +451,7 @@ namespace currency
     };
   };
   
-  struct block_header_responce
+  struct block_header_response
   {
       uint8_t major_version;
       uint8_t minor_version;
@@ -487,7 +487,7 @@ namespace currency
     struct response
     {
       std::string status;
-      block_header_responce block_header;
+      block_header_response block_header;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(block_header)
@@ -511,7 +511,7 @@ namespace currency
     struct response
     {
       std::string status;
-      block_header_responce block_header;
+      block_header_response block_header;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(block_header)
@@ -535,13 +535,45 @@ namespace currency
     struct response
     {
       std::string status;
-      block_header_responce block_header;
+      block_header_response block_header;
       
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(block_header)
         KV_SERIALIZE(status)
       END_KV_SERIALIZE_MAP()
     };
+
+  };
+
+  struct COMMAND_RPC_GET_BLOCK
+  {
+     struct request
+     {
+       std::string hash;
+       uint64_t height;
+
+       BEGIN_KV_SERIALIZE_MAP()
+         KV_SERIALIZE(hash)
+         KV_SERIALIZE(height)
+       END_KV_SERIALIZE_MAP()
+     };
+
+     struct response
+     {
+       std::string status;
+       block_header_response block_header;
+       std::vector<std::string> tx_hashes;
+       std::string blob;
+       std::string json;
+
+       BEGIN_KV_SERIALIZE_MAP()
+         KV_SERIALIZE(block_header)
+         KV_SERIALIZE(tx_hashes)
+         KV_SERIALIZE(status)
+         KV_SERIALIZE(blob)
+         KV_SERIALIZE(json)
+       END_KV_SERIALIZE_MAP()
+     };
 
   };
 
@@ -616,7 +648,6 @@ namespace currency
     {
       std::string status;
       std::list<mining::addendum> addms;
-
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(status)


### PR DESCRIPTION
Prior to this commit the JSON RPC could only retrieve block header data.
With this commit full block information can now be retrieved.

Also, I corrected the spelling of "response" because it was spelled "responce"
