### PR TITLE
Add JSON Response Data for gettransactions

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -308,6 +308,7 @@ namespace currency
     {
       blobdata blob = t_serializable_object_to_blob(tx);
       res.txs_as_hex.push_back(string_tools::buff_to_hex_nodelimer(blob));
+      res.txs_as_json.push_back(obj_to_json_str(tx));
     }
 
     BOOST_FOREACH(const auto& miss_tx, missed_txs)

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -106,12 +106,14 @@ namespace currency
 
     struct response
     {
-      std::list<std::string> txs_as_hex;  //transactions blobs as hex
+      std::list<std::string> txs_as_hex;  //Transaction blobs as hex
+      std::list<std::string> txs_as_json; //Transaction blobs translated from hex to JSON
       std::list<std::string> missed_tx;   //not found transactions
       std::string status;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(txs_as_hex)
+        KV_SERIALIZE(txs_as_json)
         KV_SERIALIZE(missed_tx)
         KV_SERIALIZE(status)
       END_KV_SERIALIZE_MAP()


### PR DESCRIPTION
Prior to this commit the gettransactions method was only returning transaction information in hex form. This commit fixes that by translating the hex into common JSON that can be parsed. For compatibility with the rest of the daemon the hex data is still returned untouched. 
