### PR TITLE
Add Daemon Version to each Peer entry

### DIFF
--- a/src/common/boost_serialization_helper.h
+++ b/src/common/boost_serialization_helper.h
@@ -42,6 +42,6 @@ namespace tools
 
     a >> obj;
     return !data_file.fail();
-    CATCH_ENTRY_L0("unserialize_obj_from_file", false);
+    CATCH_ENTRY_L0("unserialize_obj_from_file --> This could be because you are upgrading to the Rune Daemon...In which case this is a one time issue.", false);
   }
 }

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -50,8 +50,8 @@ namespace nodetool
     bool get_gray_peer_by_index(peerlist_entry& p, size_t i);
     bool append_with_peer_white(const peerlist_entry& pr);
     bool append_with_peer_gray(const peerlist_entry& pr);
-    bool set_peer_just_seen(peerid_type peer, uint32_t ip, uint32_t port);
-    bool set_peer_just_seen(peerid_type peer, const net_address& addr);
+    bool set_peer_just_seen(peerid_type peer, uint32_t ip, uint32_t port, std::string vers);
+    bool set_peer_just_seen(peerid_type peer, const net_address& addr, std::string vers);
     bool set_peer_unreachable(const peerlist_entry& pr);
     bool is_ip_allowed(uint32_t ip);
     void trim_white_peerlist();
@@ -278,16 +278,16 @@ namespace nodetool
   }
   //--------------------------------------------------------------------------------------------------
   inline
-  bool peerlist_manager::set_peer_just_seen(peerid_type peer, uint32_t ip, uint32_t port)
+  bool peerlist_manager::set_peer_just_seen(peerid_type peer, uint32_t ip, uint32_t port, std::string vers)
   {
     net_address addr;
     addr.ip = ip;
     addr.port = port;
-    return set_peer_just_seen(peer, addr);
+    return set_peer_just_seen(peer, addr, vers);
   }
   //--------------------------------------------------------------------------------------------------
   inline
-  bool peerlist_manager::set_peer_just_seen(peerid_type peer, const net_address& addr)
+  bool peerlist_manager::set_peer_just_seen(peerid_type peer, const net_address& addr, std::string vers)
   {
     TRY_ENTRY();
     CRITICAL_REGION_LOCAL(m_peerlist_lock);
@@ -296,6 +296,7 @@ namespace nodetool
     ple.adr = addr;
     ple.id = peer;
     ple.last_seen = time(NULL);
+	ple.version = vers;
     return append_with_peer_white(ple);
     CATCH_ENTRY_L0("peerlist_manager::set_peer_just_seen()", false);
   }

--- a/src/p2p/net_peerlist_boost_serialization.h
+++ b/src/p2p/net_peerlist_boost_serialization.h
@@ -23,6 +23,7 @@ namespace boost
       a & pl.adr;
       a & pl.id;
       a & pl.last_seen;
+	  a & pl.version;
     }    
   }
 }

--- a/src/p2p/p2p_protocol_defs.h
+++ b/src/p2p/p2p_protocol_defs.h
@@ -22,6 +22,11 @@ namespace nodetool
   {
     uint32_t ip;
     uint32_t port;
+
+	BEGIN_KV_SERIALIZE_MAP()
+		KV_SERIALIZE(ip)
+		KV_SERIALIZE(port)
+	END_KV_SERIALIZE_MAP()
   };
 
   struct peerlist_entry
@@ -29,6 +34,23 @@ namespace nodetool
     net_address adr;
     peerid_type id;
     time_t last_seen;
+	std::string version;
+
+	BEGIN_KV_SERIALIZE_MAP()
+		KV_SERIALIZE(adr)
+		KV_SERIALIZE(id)
+		KV_SERIALIZE(last_seen)
+		KV_SERIALIZE(version)
+	END_KV_SERIALIZE_MAP()
+  };
+
+  //It is necessary to keep this because handshakes with older daemons will fail to serialize/unserialize correctly if we use just peerlist_entry
+  //	which now includes a daemon version for each peer entry
+  struct peerlist_entry_old
+  {
+	  net_address adr;
+	  peerid_type id;
+	  time_t last_seen;
   };
 
   struct connection_entry
@@ -198,14 +220,18 @@ namespace nodetool
     {
       basic_node_data node_data;
       t_playload_type payload_data;
-      std::list<peerlist_entry> local_peerlist;
+	  std::list<peerlist_entry_old> local_peerlist;
+	  std::list<peerlist_entry> local_peerlist_w_version;
       maintainers_entry maintrs_entry;
+	  std::string version;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(node_data)
         KV_SERIALIZE(payload_data)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(local_peerlist)
+		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(local_peerlist_w_version)
         KV_SERIALIZE(maintrs_entry)
+		KV_SERIALIZE(version)
       END_KV_SERIALIZE_MAP()
     };
 	};
@@ -234,14 +260,18 @@ namespace nodetool
     {
       int64_t local_time;
       t_playload_type payload_data;
-      std::list<peerlist_entry> local_peerlist; 
+	  std::list<peerlist_entry_old> local_peerlist;
+	  std::list<peerlist_entry> local_peerlist_w_version;
       maintainers_entry maintrs_entry;
+	  std::string version;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(local_time)
         KV_SERIALIZE(payload_data)
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(local_peerlist)
+		KV_SERIALIZE_CONTAINER_POD_AS_BLOB(local_peerlist_w_version)
         KV_SERIALIZE(maintrs_entry)
+		KV_SERIALIZE(version);
       END_KV_SERIALIZE_MAP()
     };
   };

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -113,6 +113,23 @@ namespace currency
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_peerlists(const COMMAND_RPC_GET_PEERLISTS::request& req, COMMAND_RPC_GET_PEERLISTS::response& res, connection_context& cntx)
+  {
+	  if (m_p2p.get_payload_object().get_core().get_blockchain_storage().is_storing_blockchain())
+	  {
+		  res.status = CORE_RPC_STATUS_BUSY;
+		  return true;
+	  }
+
+	  std::list<nodetool::peerlist_entry> white;
+	  std::list<nodetool::peerlist_entry> gray;
+	  m_p2p.get_peerlist_manager().get_peerlist_full(gray, white);
+	  res.white_list = white;
+	  res.gray_list = gray;
+	  res.status = CORE_RPC_STATUS_OK;
+	  return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_blocks(const COMMAND_RPC_GET_BLOCKS_FAST::request& req, COMMAND_RPC_GET_BLOCKS_FAST::response& res, connection_context& cntx)
   {
     CHECK_CORE_READY();

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -38,6 +38,7 @@ namespace currency
     bool on_stop_mining(const COMMAND_RPC_STOP_MINING::request& req, COMMAND_RPC_STOP_MINING::response& res, connection_context& cntx);
     bool on_get_random_outs(const COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::request& req, COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::response& res, connection_context& cntx);
     bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, connection_context& cntx);
+	bool on_get_peerlists(const COMMAND_RPC_GET_PEERLISTS::request& req, COMMAND_RPC_GET_PEERLISTS::response& res, connection_context& cntx);
     bool on_set_maintainers_info(const COMMAND_RPC_SET_MAINTAINERS_INFO::request& req, COMMAND_RPC_SET_MAINTAINERS_INFO::response& res, connection_context& cntx);
     bool on_get_tx_pool(const COMMAND_RPC_GET_TX_POOL::request& req, COMMAND_RPC_GET_TX_POOL::response& res, connection_context& cntx);
     bool on_check_keyimages(const COMMAND_RPC_CHECK_KEYIMAGES::request& req, COMMAND_RPC_CHECK_KEYIMAGES::response& res, connection_context& cntx);
@@ -87,6 +88,7 @@ namespace currency
       MAP_URI_AUTO_JON2("/start_mining", on_start_mining, COMMAND_RPC_START_MINING)
       MAP_URI_AUTO_JON2("/stop_mining", on_stop_mining, COMMAND_RPC_STOP_MINING)
       MAP_URI_AUTO_JON2("/getinfo", on_get_info, COMMAND_RPC_GET_INFO)
+	  MAP_URI_AUTO_JON2("/getpeerlists", on_get_peerlists, COMMAND_RPC_GET_PEERLISTS)
       MAP_URI2("/getfullscratchpad2", on_getfullscratchpad2)
       BEGIN_JSON_RPC_MAP("/json_rpc")
         MAP_JON_RPC("getblockcount",             on_getblockcount,              COMMAND_RPC_GETBLOCKCOUNT)

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -357,6 +357,28 @@ namespace currency
     };
   };    
   //-----------------------------------------------
+  struct COMMAND_RPC_GET_PEERLISTS
+  {
+	struct request
+	{
+		BEGIN_KV_SERIALIZE_MAP()
+		END_KV_SERIALIZE_MAP()
+	};
+
+	struct response
+	{
+		std::string status;
+		std::list<nodetool::peerlist_entry> white_list;
+		std::list<nodetool::peerlist_entry> gray_list;
+
+		BEGIN_KV_SERIALIZE_MAP()
+			KV_SERIALIZE(status)
+			KV_SERIALIZE(white_list)
+			KV_SERIALIZE(gray_list)
+		END_KV_SERIALIZE_MAP()
+	};
+  };
+  //-----------------------------------------------
   struct COMMAND_RPC_STOP_MINING
   {
     struct request


### PR DESCRIPTION
In this commit I added support to keep track of the daemon version of each peer entry. I made the handshakes between each daemon compatible with new and old daemons, and I added an RPC method to retrieve a daemon's white and gray peer lists in order to survey what remote nodes the local node has made contact with.