### PR TITLE
Add stop_daemon RPC method and add RPC API restricted mode

### DIFF
--- a/contrib/epee/include/net/http_server_handlers_map2.h
+++ b/contrib/epee/include/net/http_server_handlers_map2.h
@@ -55,8 +55,8 @@
 
 #define MAP_URI_AUTO_XML2(s_pattern, callback_f, command_type) //TODO: don't think i ever again will use xml - ambiguous and "overtagged" format
 
-#define MAP_URI_AUTO_JON2(s_pattern, callback_f, command_type) \
-    else if(query_info.m_URI == s_pattern) \
+#define MAP_URI_AUTO_JON2_IF(s_pattern, callback_f, command_type, cond) \
+    else if((query_info.m_URI == s_pattern) && (cond)) \
     { \
       handled = true; \
       uint64_t ticks = misc_utils::get_tick_count(); \
@@ -79,6 +79,8 @@
       response_info.m_header_info.m_content_type = " application/json"; \
       LOG_PRINT( s_pattern << " processed with " << ticks1-ticks << "/"<< ticks2-ticks1 << "/" << ticks3-ticks2 << "ms", LOG_LEVEL_2); \
     }
+
+#define MAP_URI_AUTO_JON2(s_pattern, callback_f, command_type) MAP_URI_AUTO_JON2_IF(s_pattern, callback_f, command_type, true)
 
 #define MAP_URI_AUTO_BIN2(s_pattern, callback_f, command_type) \
     else if(query_info.m_URI == s_pattern) \
@@ -259,8 +261,8 @@ namespace epee
   response_info.m_header_info.m_content_type = " application/json"; \
   LOG_PRINT( query_info.m_URI << "[" << method_name << "] processed with " << ticks1-ticks << "/"<< ticks2-ticks1 << "/" << ticks3-ticks2 << "ms", LOG_LEVEL_2);
 
-#define MAP_JON_RPC_WE(method_name, callback_f, command_type) \
-    else if(callback_name == method_name) \
+#define MAP_JON_RPC_WE_IF(method_name, callback_f, command_type, cond) \
+    else if((callback_name == method_name) && (cond)) \
 { \
   PREPARE_OBJECTS_FROM_JSON(command_type) \
   epee::json_rpc::error_response fail_resp = AUTO_VAL_INIT(fail_resp); \
@@ -274,6 +276,8 @@ namespace epee
   FINALIZE_OBJECTS_TO_JSON(method_name) \
   return true;\
 }
+
+#define MAP_JON_RPC_WE(method_name, callback_f, command_type) MAP_JON_RPC_WE_IF(method_name, callback_f, command_type, true)
 
 #define MAP_JON_RPC_WERI(method_name, callback_f, command_type) \
     else if(callback_name == method_name) \
@@ -291,8 +295,8 @@ namespace epee
   return true;\
 }
 
-#define MAP_JON_RPC(method_name, callback_f, command_type) \
-    else if(callback_name == method_name) \
+#define MAP_JON_RPC_IF(method_name, callback_f, command_type, cond) \
+    else if((callback_name == method_name) && (cond)) \
 { \
   PREPARE_OBJECTS_FROM_JSON(command_type) \
   if(!callback_f(req.params, resp.result, m_conn_context)) \
@@ -308,6 +312,8 @@ namespace epee
   FINALIZE_OBJECTS_TO_JSON(method_name) \
   return true;\
 }
+
+#define MAP_JON_RPC(method_name, callback_f, command_type) MAP_JON_RPC_IF(method_name, callback_f, command_type, true)
 
 #define MAP_JON_RPC_N(callback_f, command_type) MAP_JON_RPC(command_type::methodname(), callback_f, command_type)
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -39,6 +39,7 @@ namespace currency
     bool on_get_random_outs(const COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::request& req, COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::response& res, connection_context& cntx);
     bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, connection_context& cntx);
 	bool on_get_peerlists(const COMMAND_RPC_GET_PEERLISTS::request& req, COMMAND_RPC_GET_PEERLISTS::response& res, connection_context& cntx);
+	bool on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res, connection_context& cntx);
     bool on_set_maintainers_info(const COMMAND_RPC_SET_MAINTAINERS_INFO::request& req, COMMAND_RPC_SET_MAINTAINERS_INFO::response& res, connection_context& cntx);
     bool on_get_tx_pool(const COMMAND_RPC_GET_TX_POOL::request& req, COMMAND_RPC_GET_TX_POOL::response& res, connection_context& cntx);
     bool on_check_keyimages(const COMMAND_RPC_CHECK_KEYIMAGES::request& req, COMMAND_RPC_CHECK_KEYIMAGES::response& res, connection_context& cntx);
@@ -85,10 +86,11 @@ namespace currency
       MAP_URI_AUTO_BIN2("/check_keyimages.bin", on_check_keyimages, COMMAND_RPC_CHECK_KEYIMAGES)
       MAP_URI_AUTO_JON2("/gettransactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
       MAP_URI_AUTO_JON2("/sendrawtransaction", on_send_raw_tx, COMMAND_RPC_SEND_RAW_TX)
-      MAP_URI_AUTO_JON2("/start_mining", on_start_mining, COMMAND_RPC_START_MINING)
-      MAP_URI_AUTO_JON2("/stop_mining", on_stop_mining, COMMAND_RPC_STOP_MINING)
+	  MAP_URI_AUTO_JON2_IF("/start_mining", on_start_mining, COMMAND_RPC_START_MINING, !m_restricted)
+	  MAP_URI_AUTO_JON2_IF("/stop_mining", on_stop_mining, COMMAND_RPC_STOP_MINING, !m_restricted)
       MAP_URI_AUTO_JON2("/getinfo", on_get_info, COMMAND_RPC_GET_INFO)
-	  MAP_URI_AUTO_JON2("/getpeerlists", on_get_peerlists, COMMAND_RPC_GET_PEERLISTS)
+	  MAP_URI_AUTO_JON2_IF("/getpeerlists", on_get_peerlists, COMMAND_RPC_GET_PEERLISTS, !m_restricted)
+	  MAP_URI_AUTO_JON2_IF("/stop_daemon", on_stop_daemon, COMMAND_RPC_STOP_DAEMON, !m_restricted)
       MAP_URI2("/getfullscratchpad2", on_getfullscratchpad2)
       BEGIN_JSON_RPC_MAP("/json_rpc")
         MAP_JON_RPC("getblockcount",             on_getblockcount,              COMMAND_RPC_GETBLOCKCOUNT)
@@ -99,12 +101,12 @@ namespace currency
         MAP_JON_RPC_WE("getblockheaderbyhash",   on_get_block_header_by_hash,   COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH)
         MAP_JON_RPC_WE("getblockheaderbyheight", on_get_block_header_by_height, COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT)
         MAP_JON_RPC_WE("getblock",               on_get_block,                  COMMAND_RPC_GET_BLOCK)
-        MAP_JON_RPC_WE("get_connections",        on_get_connections,            COMMAND_RPC_GET_CONNECTIONS)
+        MAP_JON_RPC_WE_IF("get_connections",     on_get_connections,            COMMAND_RPC_GET_CONNECTIONS, !m_restricted)
         MAP_JON_RPC_WE("get_alias_details",      on_get_alias_details,          COMMAND_RPC_GET_ALIAS_DETAILS)
         MAP_JON_RPC_WE("get_all_alias_details",  on_get_all_aliases,            COMMAND_RPC_GET_ALL_ALIASES)
         MAP_JON_RPC_WE("get_alias_by_address",   on_alias_by_address,           COMMAND_RPC_GET_ALIASES_BY_ADDRESS)
         MAP_JON_RPC_WE("get_addendums",          on_get_addendums,              COMMAND_RPC_GET_ADDENDUMS)
-        MAP_JON_RPC("reset_transaction_pool",    on_reset_transaction_pool,     COMMAND_RPC_RESET_TX_POOL)
+		MAP_JON_RPC_IF("reset_transaction_pool", on_reset_transaction_pool,     COMMAND_RPC_RESET_TX_POOL, !m_restricted)
         //remote miner rpc
         MAP_JON_RPC_N(on_login,            mining::COMMAND_RPC_LOGIN)
         MAP_JON_RPC_N(on_getjob,           mining::COMMAND_RPC_GETJOB)
@@ -133,6 +135,7 @@ namespace currency
     nodetool::node_server<currency::t_currency_protocol_handler<currency::core> >& m_p2p;
     std::string m_port;
     std::string m_bind_ip;
+	bool m_restricted;
     //mining stuff
     epee::critical_section m_session_jobs_lock;
     std::map<std::string, currency::block> m_session_jobs; //session id -> blob

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -379,6 +379,24 @@ namespace currency
 	};
   };
   //-----------------------------------------------
+  struct COMMAND_RPC_STOP_DAEMON
+  {
+	  struct request
+	  {
+		  BEGIN_KV_SERIALIZE_MAP()
+		  END_KV_SERIALIZE_MAP()
+	  };
+
+	  struct response
+	  {
+		  std::string status;
+
+		  BEGIN_KV_SERIALIZE_MAP()
+			  KV_SERIALIZE(status)
+		  END_KV_SERIALIZE_MAP()
+	  };
+  };
+  //-----------------------------------------------
   struct COMMAND_RPC_STOP_MINING
   {
     struct request


### PR DESCRIPTION
The stop_daemon RPC method does exactly what it sounds like... it stops the daemon. It is simultaneously added with the restricted mode of the RPC api so that a public node can be run in "read only" mode. This is needed as more RPC methods are added because we wouldn't want, for example, someone shutting down a public node remotely.