### PR TITLE
epee: regularly cleanup connections we kept a reference to

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -248,6 +248,7 @@ namespace net_utils
     void handle_accept(const boost::system::error_code& e);
 
     bool is_thread_worker();
+    bool cleanup_connections();
 
     /// The io_service used to perform asynchronous operations.
     std::unique_ptr<boost::asio::io_service> m_io_service_local_instance;
@@ -259,7 +260,7 @@ namespace net_utils
     /// The next connection to be accepted.
     connection_ptr new_connection_;
     std::mutex connections_mutex;
-    std::deque<connection_ptr> connections_;
+    std::deque<std::pair<boost::system_time, connection_ptr>> connections_;
     std::atomic<bool> m_stop_signal_sent;
     uint32_t m_port;
     volatile uint32_t m_sockets_count;


### PR DESCRIPTION
Since connections from the ::connect method are now kept in
a deque to be able to cancel them on exit, this leaks both
memory and a file descriptor. Here, we clean those up after
30 seconds, to avoid this. 30 seconds is higher then the
5 second timeout used in the async code, so this should be
safe. However, this is an assumption which would break if
that async code was to start relying on longer timeouts.
from https://github.com/monero-project/monero/commit/22581a04415c571461368c434ece72e5756d4fbd

credit to https://github.com/moneromooo-monero

hopefully this is all that's needed to clean this up